### PR TITLE
Abort save in switched MS context

### DIFF
--- a/admin/class-project-edit.php
+++ b/admin/class-project-edit.php
@@ -195,6 +195,10 @@ final class CCP_Project_Edit {
 	 * @return void
 	 */
 	public function update( $post_id ) {
+		
+		// If we're on multisite with a switched context we don't save anything (as it would end up on the wrong site)
+		if ( is_multisite() && ms_is_switched() ) 
+			return;
 
 		$this->manager->update( $post_id );
 


### PR DESCRIPTION
This function is triggered via `save_post` which also fires if we save in a switched context on multisite. So we test for that case and abort if applicable.